### PR TITLE
Adjust legend spacing to avoid text-colour overlaps

### DIFF
--- a/bin/ntsynt_viz_plot_synteny_blocks_ribbon_plot.R
+++ b/bin/ntsynt_viz_plot_synteny_blocks_ribbon_plot.R
@@ -152,7 +152,7 @@ make_plot <- function(links, sequences, painting, colours_df, add_scale_bar = FA
   #geom_seq_label(aes(label = seq_id), vjust = 1.1, size = 4) + # Can add seq labels if desired
   theme(axis.text = element_text(size = 25, face = "italic"),
         legend.position = "bottom",
-        legend.text = element_text(size = 15)) +
+        legend.text = element_text(size = 15, margin = margin(r=10))) +
   scale_fill_manual(values = colours,
                     breaks = sequences_filt) +
   scale_colour_manual(values = colours,


### PR DESCRIPTION
- With longer legend labels, could see overlap between the text and the adjacent colour box
- Adds margin to the right of label to avoid this