### PR TITLE
Consider sequence filtering when choosing ribbon colours

### DIFF
--- a/bin/ntsynt_viz.smk
+++ b/bin/ntsynt_viz.smk
@@ -227,7 +227,7 @@ rule chrom_sorting:
             fais = sort_fais(input.fais, name_conversion, input.orders)
         else:
             fais = sort_fais_no_name_conversion(input.fais, input.orders)
-        shell(f"ntsynt_viz_sort_sequences.py --fai {fais} --blocks {input.blocks} --lengths {input.sequences} --prefix {prefix} --min-length {min_len}")
+        shell(f"ntsynt_viz_sort_sequences.py --fai {fais} --blocks {input.blocks} --lengths {input.sequences} --prefix {prefix} --min-length {min_seq_length}")
 
 rule chrom_paint:
     input: links = rules.gggenomes_files.output.links

--- a/bin/ntsynt_viz.smk
+++ b/bin/ntsynt_viz.smk
@@ -227,7 +227,7 @@ rule chrom_sorting:
             fais = sort_fais(input.fais, name_conversion, input.orders)
         else:
             fais = sort_fais_no_name_conversion(input.fais, input.orders)
-        shell(f"ntsynt_viz_sort_sequences.py --fai {fais} --blocks {input.blocks} --lengths {input.sequences} --prefix {prefix}")
+        shell(f"ntsynt_viz_sort_sequences.py --fai {fais} --blocks {input.blocks} --lengths {input.sequences} --prefix {prefix} --min-length {min_len}")
 
 rule chrom_paint:
     input: links = rules.gggenomes_files.output.links

--- a/bin/ntsynt_viz_sort_sequences.py
+++ b/bin/ntsynt_viz_sort_sequences.py
@@ -126,7 +126,6 @@ def get_target_genome_seqs(fai_filename, min_length):
             if length >= min_length:
                 target_genome_seqs[seq_id] = i
                 i += 1
-        
     return target_genome_seqs
 
 

--- a/bin/ntsynt_viz_sort_sequences.py
+++ b/bin/ntsynt_viz_sort_sequences.py
@@ -115,10 +115,18 @@ def get_mapped_tiles(tree, fai_filenames, tile, asm_orders):
 
     return all_asm_seq_orders
 
-def get_target_genome_seqs(fai_filename):
+def get_target_genome_seqs(fai_filename, min_length):
     "Create dictionary with key sequence name, and value index in the input file"
+    target_genome_seqs = {}
+    i = 0
     with open(fai_filename, 'r', encoding="utf-8") as fin:
-        target_genome_seqs = {line.strip().split("\t")[0]: i for i, line in enumerate(fin)}
+        for line in fin:
+            line = line.strip().split("\t")
+            seq_id, length = line[0], int(line[1])
+            if length >= min_length:
+                target_genome_seqs[seq_id] = i
+                i += 1
+        
     return target_genome_seqs
 
 
@@ -131,6 +139,7 @@ def main():
                         required=True, type=str)
     parser.add_argument("--tile", help="Tile size in bp [1 Mbp]", default=1000000, type=int)
     parser.add_argument("--lengths", help="Sequences lengths gggenomes TSV", required=True, type=str)
+    parser.add_argument("--min-length", help="Minimum sequence length", type=int, default=100000)
     parser.add_argument("--prefix", help="Output file prefix", required=True, type=str)
 
     args = parser.parse_args()
@@ -139,7 +148,7 @@ def main():
 
     asm_seq_orders = get_mapped_tiles(blocks_tree, args.fais, args.tile, asm_orders)
 
-    target_genome_seqs = get_target_genome_seqs(args.fais[0])
+    target_genome_seqs = get_target_genome_seqs(args.fais[0], args.min_length)
 
     with open(args.lengths, 'r', encoding='utf-8') as fin, \
          open(f"{args.prefix}.sequence_lengths.sorted.tsv", 'w', encoding="utf-8") as output_lengths_gggenome, \


### PR DESCRIPTION
- Previously, if there were many small sequences (less than `--seq_length`), it could interfere with the chosen colour scale for the ribbon plot
  - Could end up with some colours being very similar because colours were chosen based on the total number of sequences, even if they were filtered out with the length threshold
- This fixes that issue - the number of colours chosen matches the number of chromosomes of the target genome plotted, ensuring the best colour choice for the ribbons