### PR TITLE
Add option --order to specify full genome ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ export PATH=/path/to/ntsynt-viz/github/ntSynt-viz/bin:$PATH
 ```
 usage: ntsynt_viz.py [-h] --blocks BLOCKS --fais FAIS [FAIS ...] [--name_conversion NAME_CONVERSION] [--tree TREE] [--target-genome TARGET_GENOME] [--normalize]
                      [--indel INDEL] [--length LENGTH] [--seq_length SEQ_LENGTH] [--keep KEEP [KEEP ...]] [--centromeres CENTROMERES] [--haplotypes HAPLOTYPES]
-                     [--prefix PREFIX] [--format {png,pdf,svg}] [--scale SCALE] [--height HEIGHT] [--width WIDTH] [--dpi DPI] [--no-arrow] [--ribbon_adjust RIBBON_ADJUST]
-                     [-f] [-n] [-v]
+                     [--order ORDER] [--prefix PREFIX] [--format {png,pdf,svg}] [--scale SCALE] [--height HEIGHT] [--width WIDTH] [--dpi DPI] [--no-arrow]
+                     [--ribbon_adjust RIBBON_ADJUST] [-f] [-n] [-v]
 
 Visualizing multi-genome synteny
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
 
 required arguments:
@@ -81,21 +81,23 @@ required arguments:
 
 main plot formatting arguments:
   --name_conversion NAME_CONVERSION
-                        TSV for converting names in the blocks TSV (old -> new). IMPORTANT: new names cannot have spaces. If you want to have spaces in the final ribbon
-                        plot, use the special character '_'. All underscores in the new name will be converted to spaces.
+                        TSV for converting names in the blocks TSV (old -> new). IMPORTANT: new names cannot have spaces. If you want to have spaces in the
+                        final ribbon plot, use the special character '_'. All underscores in the new name will be converted to spaces.
   --tree TREE           User-input tree file in newick format. If specified, this tree will be plotted next to the output ribbon plot, and used for ordering the
-                        assemblies. The names in the newick file must match the new names if --name_conversion is specified, or the genome file names in the synteny
-                        blocks input file otherwise. If not specified, the synteny blocks will be used to estimate pairwise distances for the genome ordering and
-                        associated tree.
+                        assemblies. The names in the newick file must match the new names if --name_conversion is specified, or the genome file names in the
+                        synteny blocks input file otherwise. If not specified, the synteny blocks will be used to estimate pairwise distances for the genome
+                        ordering and associated tree.
   --target-genome TARGET_GENOME
-                        Target genome. If specified, this genome will be at the top of the ribbon plot, with ribbons coloured based on its chromosomes and (if applicable)
-                        other chromosomes normalized to it. If not specified, the top genome will be arbitrary.
+                        Target genome. If specified, this genome will be at the top of the ribbon plot, with ribbons coloured based on its chromosomes and (if
+                        applicable) other chromosomes normalized to it. If not specified, the top genome will be arbitrary.
   --normalize           Normalize strand of chromosomes relative to the target (top) genome in the ribbon plots
   --centromeres CENTROMERES
-                        TSV file with centromere positions. Must have the headers: bin_id,seq_id,start,end. bin_id must match the new names from --name_conversion or the
-                        genome names if --name_conversion is not specified. seq_id is the chromosome name.
+                        TSV file with centromere positions. Must have the headers: bin_id,seq_id,start,end. bin_id must match the new names from
+                        --name_conversion or the genome names if --name_conversion is not specified. seq_id is the chromosome name.
   --haplotypes HAPLOTYPES
                         File listing haplotype assembly names: TSV, maternal/paternal assembly file names separated by tabs.
+  --order ORDER         Optional file specifying the order of genomes in the ribbon plot. If supplied, will override synteny distance-based ordering. If --tree
+                        supplied, the ordering must be compatible with the phylogenetic tree.
   --no-arrow            Only used with --normalize; do not draw arrows indicating reverse-complementation
 
 block filtering arguments:
@@ -115,8 +117,8 @@ output arguments:
   --width WIDTH         Width of plot in cm [50]
   --dpi DPI             Resolution of output plot - png output only [300]
   --ribbon_adjust RIBBON_ADJUST
-                        Ratio for adjusting spacing beside ribbon plot. Increase if ribbon plot labels are cut off, and decrease to reduce the white space to the left of
-                        the ribbon plot [0.1]
+                        Ratio for adjusting spacing beside ribbon plot. Increase if ribbon plot labels are cut off, and decrease to reduce the white space to
+                        the left of the ribbon plot [0.1]
 
 execution arguments:
   -f, --force           Force a re-run of the entire pipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,13 @@ jobs:
       ntsynt_viz.py --blocks great-apes.ntSynt.synteny_blocks.tsv --fais fais.tsv  --name_conversion great-apes.name-conversions.tsv  --prefix great-apes_ribbon-plots_no-tree --ribbon_adjust 0.15 --scale 2e9 --target-genome Pan_paniscus --format svg --force
     displayName: Run Example 3 test (SVG output)
 
+   - script: |
+      source activate ntsynt_viz_ci
+      export PATH=$(pwd)/bin:$PATH
+      cd tests
+      ntsynt_viz.py --blocks great-apes.ntSynt.synteny_blocks.tsv --fais fais.tsv  --name_conversion great-apes.name-conversions.tsv  --prefix great-apes_ribbon-plots_tree_order --ribbon_adjust 0.15 --scale 2e9 --order test_order.tsv --format png --force
+    displayName: Run Example 4 test (PNG output) 
+
   - publish: tests/great-apes_ribbon-plots_ribbon-plot_tree.png
     artifact: Example1
 
@@ -72,6 +79,9 @@ jobs:
 
   - publish: tests/great-apes_ribbon-plots_no-tree_ribbon-plot.svg
     artifact: Example3
+
+  - publish: tests/great-apes_ribbon-plots_tree_order_ribbon-plot.png
+    artifact: Example4
 
 
 - job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
       ntsynt_viz.py --blocks great-apes.ntSynt.synteny_blocks.tsv --fais fais.tsv  --name_conversion great-apes.name-conversions.tsv  --prefix great-apes_ribbon-plots_no-tree --ribbon_adjust 0.15 --scale 2e9 --target-genome Pan_paniscus --format svg --force
     displayName: Run Example 3 test (SVG output)
 
-   - script: |
+  - script: |
       source activate ntsynt_viz_ci
       export PATH=$(pwd)/bin:$PATH
       cd tests

--- a/bin/ntsynt_viz.py
+++ b/bin/ntsynt_viz.py
@@ -116,6 +116,9 @@ def main():
 
     if args.name_conversion:
         check_name_conversion(args.name_conversion, parser)
+        
+    if args.target_genome and args.order:
+        parser.error("Please specify only one of --target-genome or --order, not both.")
 
     if len(args.fais) == 1:
         args.fais = read_fai_files(args.fais[0])

--- a/bin/ntsynt_viz.py
+++ b/bin/ntsynt_viz.py
@@ -116,7 +116,7 @@ def main():
 
     if args.name_conversion:
         check_name_conversion(args.name_conversion, parser)
-        
+
     if args.target_genome and args.order:
         parser.error("Please specify only one of --target-genome or --order, not both.")
 

--- a/bin/ntsynt_viz.py
+++ b/bin/ntsynt_viz.py
@@ -79,6 +79,10 @@ def main():
     main_formatting_group.add_argument("--haplotypes", help="File listing haplotype assembly names: TSV, "
                         "maternal/paternal assembly file names separated by tabs.",
                         required=False, type=str)
+    main_formatting_group.add_argument("--order", help="Optional file specifying the order of genomes in the ribbon plot. "\
+                                       "If supplied, will override synteny distance-based ordering. "\
+                                       "If --tree supplied, the ordering must be compatible with the phylogenetic tree.",
+                                       required=False, type=str)
     output_group.add_argument("--prefix", help="Prefix for output files [ntSynt-viz_ribbon-plot]",
                               required=False, type=str, default="ntSynt-viz_ribbon-plot")
     output_group.add_argument("--format", help="Output format of plot [png]",
@@ -143,6 +147,8 @@ def main():
         cmd += f"keep=\"{args.keep}\" "
     if args.format == "png":
         cmd += f"dpi={args.dpi} "
+    if args.order:
+        cmd += f"order={args.order} "
     if args.tree:
         cmd += f"tree={args.tree} "
         target = "gggenomes_ribbon_plot_tree"

--- a/bin/ntsynt_viz.py
+++ b/bin/ntsynt_viz.py
@@ -79,9 +79,12 @@ def main():
     main_formatting_group.add_argument("--haplotypes", help="File listing haplotype assembly names: TSV, "
                         "maternal/paternal assembly file names separated by tabs.",
                         required=False, type=str)
-    main_formatting_group.add_argument("--order", help="Optional file specifying the order of genomes in the ribbon plot. "\
+    main_formatting_group.add_argument("--order",
+                                       help="Optional file specifying the order of genomes "\
+                                           "in the ribbon plot. "\
                                        "If supplied, will override synteny distance-based ordering. "\
-                                       "If --tree supplied, the ordering must be compatible with the phylogenetic tree.",
+                                       "If --tree supplied, the ordering must be compatible "\
+                                           "with the phylogenetic tree.",
                                        required=False, type=str)
     output_group.add_argument("--prefix", help="Prefix for output files [ntSynt-viz_ribbon-plot]",
                               required=False, type=str, default="ntSynt-viz_ribbon-plot")

--- a/bin/ntsynt_viz.smk
+++ b/bin/ntsynt_viz.smk
@@ -28,6 +28,7 @@ haplotypes = config["haplotypes"] if "haplotypes" in config else []
 keep = " ".join(config["keep"]) if "keep" in config else []
 min_seq_length = config["min_seq_length"] if "min_seq_length" in config else 500000
 res = config["dpi"] if "dpi" in config else 300
+orders = config.get("order", [])
 
 def sort_fais(fai_list, name_conversion, orders):
     "Based on the name conversion TSV, sort the FAIs based on orders"
@@ -161,8 +162,11 @@ rule orders:
         prefix = f"{prefix}_est-distances",
         tree_flag = "--tree" if tree is not None else "",
         haplotypes = f"--haplotypes {haplotypes}" if haplotypes else ""
-    shell:
-        "ntsynt_viz_output_orders.py -p {params.prefix} {params.tree_flag} {params.haplotypes}"
+    run:
+        if orders:
+            shell("ln -sf {orders} {output.orders}")
+        else:
+            shell("ntsynt_viz_output_orders.py -p {params.prefix} {params.tree_flag} {params.haplotypes}")
 
 rule nudges:
     input: 

--- a/tests/test_order.tsv
+++ b/tests/test_order.tsv
@@ -1,0 +1,6 @@
+Hylobates_pileatus
+Pongo_pygmaeus
+Gorilla_gorilla
+Homo_sapiens
+Pan_troglodytes
+Pan_paniscus


### PR DESCRIPTION
- Added option `--order` to allow users to specify the exact order of the genomes top-to-bottom
  - Expects a file listing the desired order (newline-separated)
  - If a name conversion TSV is input, the naming in the orders file must match the new file names
- If the order and a tree are both supplied, the order must be a possible topology of the input tree - otherwise, an error will be output